### PR TITLE
Within subshell, consistently use the same config file

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -53,6 +53,10 @@ class Application extends \Symfony\Component\Console\Application {
    */
   public function doRun(InputInterface $input, OutputInterface $output) {
     $workingDir = $input->getParameterOption(array('--cwd'));
+    if (empty($workingDir) && getenv('LOCO_PRJ')) {
+      $workingDir = getenv('LOCO_PRJ');
+    }
+
     if (FALSE !== $workingDir && '' !== $workingDir) {
       if (!is_dir($workingDir)) {
         throw new \RuntimeException("Invalid working directory specified, $workingDir does not exist.");

--- a/src/Command/LocoCommandTrait.php
+++ b/src/Command/LocoCommandTrait.php
@@ -4,6 +4,7 @@ namespace Loco\Command;
 use Loco\Loco;
 use Loco\LocoSystem;
 use Loco\LocoVolume;
+use Loco\Utils\File;
 use Loco\Utils\Shell;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -47,7 +48,10 @@ trait LocoCommandTrait {
   }
 
   public function pickConfig() {
-    $c = Loco::filter('loco.config.find', ['file' => NULL]);
+    // If you setup an environment with a specific config file (`loco env -c FILE` or `loco shell -c FILE`), then
+    // the same file should be used in subsequent sub commands (`loco run SVC`).
+    $envFile = getenv('LOCO_CFG_YML') ? File::toAbsolutePath(getenv('LOCO_CFG_YML')) : NULL;
+    $c = Loco::filter('loco.config.find', ['file' => $envFile]);
     if ($c['file']) {
       return $c['file'];
     }


### PR DESCRIPTION
Use Case
--------

This patch improves the usability for the following situation:

(1) Suppose you startup an environment with a specific config file, e.g.

* `loco env -c $ALT_FILE` or
* `loco shell -c $ALT_FILE`

(2) Within that subshell, you then run some commands for specific services:

* `loco init $SVC`
* `loco run $SVC`
* `loco clean $SVC`

Before
------

The `loco env` or `loco shell` will setup system-level variables using `$ALT_FILE`.  But when you run the services, it uses the _default_ configuration file (_not_ `$ALT_FILE`).

After
-----

When you run the services, it will _inherit_ the effective configuration file from earlier. Similarily, it will also inherit the LOCO_PRJ (CWD) for purposes of runnig service tasks.

Comment
-------

This changes the behavior if you purposefully run multiple/overlapping configurations.  But in my usage, that's never been intentional. The intent is generally to have one full definition for a project -- and use that definition for any subshells/services.