### PR TITLE
Background Execution - Add "start" command. Improve "stop"+"clean" commands. Improve logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ $ loco run
 
 To stop, press Ctrl-C.
 
+Alternatively, you may start and stop services in the background:
+
+```
+$ loco start
+...
+$ loco stop
+```
+
 `loco` is a functional proof-of-concept. For more details, see the [working example (*loco*lamp)](https://github.com/totten/locolamp) and [draft specification/todos](doc/specs.md).
 
 ## More information

--- a/doc/specs.md
+++ b/doc/specs.md
@@ -49,9 +49,13 @@ services:
     ## The 'run' is the main bash command to execute and monitor.
     run: BASH_COMMAND
 
-    ## By default, 'run' works with non-forking/foreground daemons.
-    ## If the daemon forks
+    ## Daemons should write their PID to a control file.
+    ## This is required for 'start'/'stop' commands. (It is suggested for 'run'.)
     pid_file: FILE_PATH
+
+    ## Optionally, redirect the STDOUT/STDERR for the process to file.
+    ## If omitted, then output is either written to console ('loco run') or a general log file ('loco start').
+    log_file: FILE_PATH
 
     ## A message to display after the services have started.
     message: STRING

--- a/src/Application.php
+++ b/src/Application.php
@@ -8,6 +8,7 @@ use Loco\Command\ExportCommand;
 use Loco\Command\InitCommand;
 use Loco\Command\RunCommand;
 use Loco\Command\ShellCommand;
+use Loco\Command\StartCommand;
 use Loco\Command\StatusCommand;
 use Loco\Command\StopCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -81,6 +82,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new RunCommand();
     $commands[] = new InitCommand();
     $commands[] = new CleanCommand();
+    $commands[] = new StartCommand();
     $commands[] = new StopCommand();
     $commands[] = new StatusCommand();
     $commands[] = new ExportCommand();

--- a/src/Command/CleanCommand.php
+++ b/src/Command/CleanCommand.php
@@ -35,7 +35,9 @@ class CleanCommand extends \Symfony\Component\Console\Command\Command {
       }
     }
 
-    $output->writeln("<info>[<comment>loco</comment>] Cleanup services: " . $this->formatList($svcNames) . "</info>", OutputInterface::VERBOSITY_VERBOSE);
+    $this->awaitStopped($output, $svcs);
+
+    $output->writeln("<info>[<comment>loco</comment>] Cleanup data: " . $this->formatList($svcNames) . "</info>", OutputInterface::VERBOSITY_VERBOSE);
     foreach ($svcs as $svc) {
       $svc->cleanup($output);
     }

--- a/src/Command/CleanCommand.php
+++ b/src/Command/CleanCommand.php
@@ -1,8 +1,10 @@
 <?php
 namespace Loco\Command;
 
+use Loco\LocoSystem;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CleanCommand extends \Symfony\Component\Console\Command\Command {
@@ -14,6 +16,7 @@ class CleanCommand extends \Symfony\Component\Console\Command\Command {
       ->setName('clean')
       ->setDescription('Clean out the service data folders')
       ->addArgument('service', InputArgument::IS_ARRAY, 'Service name(s). (Default: all)')
+      ->addOption('sig', 'k', InputOption::VALUE_REQUIRED, 'Kill signal', SIGTERM)
       ->setHelp('Clean out the service data folders');
     $this->configureSystemOptions();
   }
@@ -23,16 +26,40 @@ class CleanCommand extends \Symfony\Component\Console\Command\Command {
     $svcNames = $input->getArgument('service')
       ? $input->getArgument('service')
       : array_keys($system->services);
+    $svcs = $this->asServices($system, $svcNames);
+
+    $output->writeln("<info>[<comment>loco</comment>] Stop services: " . $this->formatList($svcNames) . "</info>", OutputInterface::VERBOSITY_VERBOSE);
+    foreach ($svcs as $svc) {
+      if (!empty($svc->pid_file)) {
+        $svc->kill($output, $input->getOption('sig'));
+      }
+    }
 
     $output->writeln("<info>[<comment>loco</comment>] Cleanup services: " . $this->formatList($svcNames) . "</info>", OutputInterface::VERBOSITY_VERBOSE);
+    foreach ($svcs as $svc) {
+      $svc->cleanup($output);
+    }
 
+    return 0;
+  }
+
+  /**
+   * @param \Loco\LocoSystem $system
+   * @param array $svcNames
+   * @return \Loco\LocoService[]
+   * @throws \Exception
+   */
+  protected function asServices(LocoSystem $system, array $svcNames): array {
+    $svcs = [];
     foreach ($svcNames as $svcName) {
       if (empty($system->services[$svcName])) {
         throw new \Exception("Unknown service: $svcName");
       }
-      $system->services[$svcName]->cleanup($output);
+      else {
+        $svcs[$svcName] = $system->services[$svcName];
+      }
     }
-    return 0;
+    return $svcs;
   }
 
 }

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -153,21 +153,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command {
             $blacklist[$name] = $name;
           }
           else {
-            $pid = pcntl_fork();
-            if ($pid == -1) {
-              die("($name) Failed to fork");
-            }
-            elseif ($pid) {
-              $this->procs[$name]['pid'] = $pid;
-            }
-            else {
-              Shell::applyEnv($env);
-              $cmd = $env->evaluate($svc->run);
-              $this->output->writeln("<info>[<comment>$name</comment>] Start service: <comment>$cmd</comment></info>");
-              passthru($svc->run, $ret);
-              $this->output->writeln("<info>[<comment>$name</comment>] Exited (<comment>$ret</comment>)</info>");
-              exit($ret);
-            }
+            $this->procs[$name]['pid'] = $svc->spawn($output);
           }
 
           if ($svc->message) {

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Loco\Command;
+
+use Loco\LocoVolume;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class StartCommand extends \Symfony\Component\Console\Command\Command {
+
+  use LocoCommandTrait;
+
+  /**
+   * @var \Symfony\Component\Console\Output\OutputInterface
+   */
+  protected $output;
+
+  protected function configure() {
+    $this
+      ->setName('start')
+      ->setAliases(array())
+      ->setDescription('Start the service(s) in the background (experimental)')
+      ->addArgument('service', InputArgument::IS_ARRAY, 'Service name(s). Separated by commas or spaces. (Default: all)')
+      ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force initialization, overwriting an existing data folder')
+      ->setHelp(implode("\n", [
+        "Limitations:",
+        "- Services must generate their own pidFile",
+        "- If a service dies, it does not try to re-start.",
+      ]));
+    $this->configureSystemOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    declare(ticks = 1);
+
+    $system = $this->initSystem($input, $output);
+    $services = $this->pickServices($system, $input->getArgument('service'));
+    $forceables = $this->pickForceables($input->getOption('force'), $input->getArgument('service'), $services);
+
+    $output->writeln("<info>[<comment>loco</comment>] Start services: " . $this->formatList(array_keys($services)) . "</info>", OutputInterface::VERBOSITY_VERBOSE);
+
+    $this->output = $output;
+
+    if (empty($services)) {
+      $output->writeln("<error>No services to run</error>");
+      return 1;
+    }
+
+    foreach ($services as $svcName => $svc) {
+      /** @var \Loco\LocoService $svc */
+      if (!($svc instanceof LocoVolume)) {
+        if (!empty($svc->run) && empty($svc->pid_file)) {
+          $output->writeln("<error>Service \"{$svcName}\" is not compatible with \"loco start\". Service must define \"run\" and \"pidFile\".</error>");
+          return 1;
+        }
+      }
+    }
+
+    $postStartupMessages = [];
+
+    foreach ($services as $svcName => $svc) {
+      /** @var \Loco\LocoService $svc */
+      if ($svc->isRunning()) {
+        $this->output->writeln("<info>[<comment>$svcName</comment>] Service already running. Ignoring.</info>");
+        continue;
+      }
+
+      /** @var \Loco\LocoEnv $env */
+      $env = $svc->createEnv();
+
+      InitCommand::doInit($svc, in_array($svc->name, $forceables), $output);
+      if ($svc->run) {
+        $svc->spawn($output);
+      }
+      if ($svc->message) {
+        $postStartupMessages[] = $env->evaluate("<info>[<comment>$svcName</comment>] {$svc->message}</info>");
+      }
+    }
+
+    if (!empty($postStartupMessages)) {
+      $this->printStartupSummary($postStartupMessages);
+    }
+
+    return 0;
+  }
+
+  protected function printStartupSummary(array $postStartupMessages): void {
+    $this->output->writeln("\n");
+    $this->output->writeln("<info>======================[ Startup Summary ]======================</info>");
+    foreach ($postStartupMessages as $message) {
+      $this->output->writeln($message);
+    }
+    $this->output->writeln("\n<info>Services are starting. To shutdown, run <comment>loco stop</comment>.</info>");
+    $this->output->writeln("<info>===============================================================</info>");
+  }
+
+}

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -55,6 +55,10 @@ class StartCommand extends \Symfony\Component\Console\Command\Command {
           $output->writeln("<error>Service \"{$svcName}\" is not compatible with \"loco start\". Service must define \"run\" and \"pidFile\".</error>");
           return 1;
         }
+
+        if (empty($svc->log_file)) {
+          $svc->log_file = '${LOCO_SVC_VAR}/loco.log';
+        }
       }
     }
 

--- a/src/Command/StopCommand.php
+++ b/src/Command/StopCommand.php
@@ -31,6 +31,9 @@ class StopCommand extends \Symfony\Component\Console\Command\Command {
         $svc->kill($output, $input->getOption('sig'));
       }
     }
+
+    $this->awaitStopped($output, $svcs);
+
     return 0;
   }
 

--- a/src/Command/StopCommand.php
+++ b/src/Command/StopCommand.php
@@ -1,8 +1,6 @@
 <?php
 namespace Loco\Command;
 
-use Loco\LocoService;
-use Loco\LocoSystem;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -29,34 +27,11 @@ class StopCommand extends \Symfony\Component\Console\Command\Command {
     $svcs = $this->pickServices($system, $input->getArgument('service'));
     $output->writeln("<info>[<comment>loco</comment>] Stop services: " . $this->formatList(array_keys($svcs)) . "</info>", OutputInterface::VERBOSITY_VERBOSE);
     foreach (array_reverse($svcs) as $svc) {
-      static::doStop($system, $svc, $input->getOption('sig'), $input, $output);
+      if (!empty($svc->pid_file)) {
+        $svc->kill($output, $input->getOption('sig'));
+      }
     }
     return 0;
-  }
-
-  public static function doStop(LocoSystem $sys, LocoService $svc, $sig, InputInterface $input, OutputInterface $output) {
-    declare(ticks = 1);
-
-    if (empty($svc->pid_file)) {
-      return;
-    }
-    $env = $svc->createEnv();
-
-    switch ($svc->isRunning($env)) {
-      case TRUE:
-        $pid = $svc->getPid($env);
-        $output->writeln("<info>[<comment>$svc->name</comment>] Kill process (pid=<comment>$pid</comment>, sig=<comment>$sig</comment>)</info>", OutputInterface::VERBOSITY_VERBOSE);
-        posix_kill($pid, $sig);
-        break;
-
-      case FALSE:
-        $output->writeln("<info>[<comment>{$svc->name}</comment>] Already stopped</info>", OutputInterface::VERBOSITY_VERBOSE);
-        break;
-
-      case NULL:
-        $output->writeln("<info>[<comment>{$svc->name}</comment>] Does not have a PID file. Stop not supported right now.</info>", OutputInterface::VERBOSITY_VERBOSE);
-        break;
-    }
   }
 
 }

--- a/src/LocoService.php
+++ b/src/LocoService.php
@@ -254,6 +254,37 @@ class LocoService {
     // TODO: Add options for more robust template -- e.g. loco.php; loco.twig
   }
 
+  /**
+   * Send a kill signal to the running process.
+   *
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @param int $sig
+   */
+  public function kill(OutputInterface $output, int $sig = SIGTERM): void {
+    declare(ticks = 1);
+
+    if (empty($this->pid_file)) {
+      throw new \RuntimeException("Cannot kill \"{$this->name}\". No pid file configured.");
+    }
+    $env = $this->createEnv();
+
+    switch ($this->isRunning($env)) {
+      case TRUE:
+        $pid = $this->getPid($env);
+        $output->writeln("<info>[<comment>{$this->name}</comment>] Kill process (pid=<comment>$pid</comment>, sig=<comment>$sig</comment>)</info>");
+        posix_kill($pid, $sig);
+        break;
+
+      case FALSE:
+        $output->writeln("<info>[<comment>{$this->name}</comment>] Already stopped</info>", OutputInterface::VERBOSITY_VERBOSE);
+        break;
+
+      case NULL:
+        $output->writeln("<info>[<comment>{$this->name}</comment>] Does not have a PID file. Stop not supported right now.</info>", OutputInterface::VERBOSITY_VERBOSE);
+        break;
+    }
+  }
+
   public function cleanup(OutputInterface $output, LocoEnv $env = NULL) {
     $env = $env ?: $this->createEnv();
 


### PR DESCRIPTION
The `loco run` and `loco start` commands provide different forms of interaction:

* `loco run` (*existing*) starts the services in the foreground.
* `loco start` (*new*) starts the services in the background.

Enabling background execution requires some other functionality. This ground was seeded earlier for related commands (`loco status`, `loco stop`), but those commands weren't really used much before. After using them a bit with `loco start`, I added a few fixes/improvements.

Additionally, if you run a service in the background, then logging to console doesn't make sense. So this branch also adds more logging options. The `log_file:` setting can direct output to a specific file. In absence of a `log_file:`, the default behavior depends on whether you do foreground or background execution. Foreground prints to STDOUT; background goes a file.