### PR TITLE
loco start - Enforce daemonization

### DIFF
--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -78,6 +78,7 @@ class StartCommand extends \Symfony\Component\Console\Command\Command {
 
       InitCommand::doInit($svc, in_array($svc->name, $forceables), $output);
       if ($svc->run) {
+        // Fork::child(function() use ($svc, $output) {
         Fork::daemon(function() use ($svc, $output) {
           // $pipes = Fork::redirectStdIo($svc->log_file);
           // $output = new StreamOutput($pipes[1]);
@@ -85,8 +86,7 @@ class StartCommand extends \Symfony\Component\Console\Command\Command {
           $output = new NullOutput();
 
           // return $svc->run($output);
-          // return $svc->exec($output);
-          return $svc->execWithLog($output);
+          return $svc->exec($output);
         });
       }
       if ($svc->message) {

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -78,8 +78,10 @@ class StartCommand extends \Symfony\Component\Console\Command\Command {
 
       InitCommand::doInit($svc, in_array($svc->name, $forceables), $output);
       if ($svc->run) {
+        $cmd = $env->evaluate($svc->run);
+        $output->writeln("<info>[<comment>{$svc->name}</comment>] Start daemon: <comment>$cmd</comment></info>");
         // Fork::child(function() use ($svc, $output) {
-        Fork::daemon(function() use ($svc, $output) {
+        Fork::daemon(function() use ($svc) {
           // $pipes = Fork::redirectStdIo($svc->log_file);
           // $output = new StreamOutput($pipes[1]);
           // Fork::closeStdio();

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -3,9 +3,11 @@
 namespace Loco\Command;
 
 use Loco\LocoVolume;
+use Loco\Utils\Fork;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class StartCommand extends \Symfony\Component\Console\Command\Command {
@@ -76,7 +78,16 @@ class StartCommand extends \Symfony\Component\Console\Command\Command {
 
       InitCommand::doInit($svc, in_array($svc->name, $forceables), $output);
       if ($svc->run) {
-        $svc->spawn($output);
+        Fork::daemon(function() use ($svc, $output) {
+          // $pipes = Fork::redirectStdIo($svc->log_file);
+          // $output = new StreamOutput($pipes[1]);
+          // Fork::closeStdio();
+          $output = new NullOutput();
+
+          // return $svc->run($output);
+          // return $svc->exec($output);
+          return $svc->execWithLog($output);
+        });
       }
       if ($svc->message) {
         $postStartupMessages[] = $env->evaluate("<info>[<comment>$svcName</comment>] {$svc->message}</info>");

--- a/src/LocoService.php
+++ b/src/LocoService.php
@@ -300,22 +300,6 @@ class LocoService {
     $env = $this->createEnv();
     Shell::applyEnv($this->createEnv());
     $cmd = $env->evaluate($this->run);
-    $output->writeln("<info>[<comment>{$this->name}</comment>] Exec: <comment>/bin/bash -c " . escapeshellarg($cmd) . "</comment></info>");
-    \pcntl_exec('/bin/bash', ['-c', $cmd]);
-  }
-
-  /**
-   * Run the service. Replace the current PHP process.
-   *
-   * This command does not return.
-   *
-   * @see pcntl_exec
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
-   */
-  public function execWithLog(OutputInterface $output): void {
-    $env = $this->createEnv();
-    Shell::applyEnv($this->createEnv());
-    $cmd = $env->evaluate($this->run);
 
     if ($this->log_file) {
       $logFile = $env->evaluate($this->log_file);

--- a/src/Utils/Fork.php
+++ b/src/Utils/Fork.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Loco\Utils;
+
+/**
+ * A collection fork-related helpers.
+ */
+class Fork {
+
+  /**
+   * Spawn a child process within the same terminal (STDOUT/STDERR/etc).
+   * Execute $run().
+   *
+   * @param callable $run
+   *   Main function we want to run in the child process.
+   *   If this returns a numerical or boolean value, it will determine the exit-code for the child process.
+   * @return int
+   *   The PID of the new child process.
+   */
+  public static function child(callable $run): int {
+    $pid = pcntl_fork();
+    if ($pid == -1) {
+      die("Failed to fork");
+    }
+    elseif ($pid) {
+      return $pid;
+    }
+    else {
+      $result = $run();
+      exit(static::castToExitCode($result));
+    }
+  }
+
+  /**
+   * Spawn an independent process. Detach from terminal (STDOUT/STDERR/etc).
+   * Execute $run().
+   *
+   * @param callable $run
+   *   Main function we want to run in the child process.
+   *   If this returns a numerical or boolean value, it will determine the exit-code for the child process.
+   */
+  public static function daemon(callable $run): void {
+    // Parent => Intermediate => Child
+
+    // Fork from parent to intermediate
+    $intermediatePid = pcntl_fork();
+    if ($intermediatePid === -1) {
+      die('Failed to fork (intermediate process)');
+    }
+    elseif ($intermediatePid) {
+      // We're the parent, and we've done our job.
+      return;
+    }
+
+    // Intermediate does its setup
+    posix_setsid();
+
+    // Fork from intermediate to child
+    $childPid = pcntl_fork();
+    if ($childPid === -1) {
+      die('Failed to fork (child process)');
+    }
+    elseif ($childPid) {
+      // We're the intermediate, and we've done our job.
+      exit();
+    }
+
+    // Some like https://theworld.com/~swmcd/steven/tech/daemon.html suggest doing a 'umask()' and 'chdir()' here.
+    // I'm not sure -- need to assess the significance of PWD for existing service definitions.
+
+    // Finally, the child can do its thing.
+    $result = $run();
+    exit(static::castToExitCode($result));
+  }
+
+  /**
+   * Given the return value from a $run() function, determine the corresponding exit code.
+   *
+   * @param mixed $result
+   * @return int
+   *   Exit code
+   */
+  protected static function castToExitCode($result): int {
+    if (is_numeric($result)) {
+      return (int) $result;
+    }
+    elseif ($result === NULL) {
+      return 0;
+    }
+    else {
+      return $result ? 0 : 1;
+    }
+  }
+
+  // The following are little experiments and may not necessarily be used...
+
+  /**
+   * Forcibly close STDIN, STDOUT, STDERR.
+   */
+  public static function closeStdio(): void {
+    fclose(STDIN);
+    fclose(STDOUT);
+    fclose(STDERR);
+  }
+
+  /**
+   * Close and reopen STDIN, STDOUT, STDERR.
+   *
+   * @link https://stackoverflow.com/questions/32329436/how-do-i-call-linux-dup2-from-php
+   * @param string $logFile
+   * @return array
+   */
+  public static function redirectStdIo(string $logFile): array {
+    fclose(STDIN);
+    fclose(STDOUT);
+    fclose(STDERR);
+    $STDIN = fopen("/dev/null", 'r');
+    $STDOUT = fopen($logFile, 'ab');
+    $STDERR = fopen($logFile, 'ab');
+    return [$STDIN, $STDOUT, $STDERR];
+  }
+
+}


### PR DESCRIPTION
The `loco.yml` service definitions are oriented around foreground execution. That's good for `loco run`. But for `loco start`, we don't want to daemonize. With thus update, `loco start` will wrap each service with a generic daemonization adapter.