### PR TITLE
"loco info" - Add command for viewing effective service definitions

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -5,6 +5,7 @@ use LesserEvil\ShellVerbosityIsEvil;
 use Loco\Command\CleanCommand;
 use Loco\Command\EnvCommand;
 use Loco\Command\ExportCommand;
+use Loco\Command\InfoCommand;
 use Loco\Command\InitCommand;
 use Loco\Command\RunCommand;
 use Loco\Command\ShellCommand;
@@ -81,6 +82,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new ShellCommand();
     $commands[] = new RunCommand();
     $commands[] = new InitCommand();
+    $commands[] = new InfoCommand();
     $commands[] = new CleanCommand();
     $commands[] = new StartCommand();
     $commands[] = new StopCommand();

--- a/src/Command/InfoCommand.php
+++ b/src/Command/InfoCommand.php
@@ -1,0 +1,72 @@
+<?php
+namespace Loco\Command;
+
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class InfoCommand extends \Symfony\Component\Console\Command\Command {
+
+  use LocoCommandTrait;
+
+  private $displayOptions = ['run' => NULL, 'message' => 'm', 'pid_file' => NULL, 'log_file' => NULL];
+
+  protected function configure() {
+    $this
+      ->setName('info')
+      ->setAliases(array())
+      ->setDescription('Describe the services')
+      ->addArgument('service', InputArgument::IS_ARRAY, 'Service name(s). Separated by commas or spaces. (Default: all)')
+      ->setHelp('Describe the services');
+    foreach ($this->displayOptions as $option => $shortcut) {
+      $this->addOption($option, $shortcut, InputOption::VALUE_NONE, "Display property \"$option\"");
+    }
+    $this->configureSystemOptions();
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $system = $this->initSystem($input, $output);
+    $svcNames = $input->getArgument('service')
+      ? $input->getArgument('service')
+      : array_keys($system->services);
+
+    sort($svcNames);
+
+    $showAll = !array_reduce(array_keys($this->displayOptions), function($carry, $item) use ($input) {
+      return $carry || $input->getOption($item);
+    }, FALSE);
+    $showProp = function(string $name) use ($input, $showAll) {
+      return $showAll || ($input->hasOption($name) && $input->getOption($name));
+    };
+
+    $this->applyDaemonDefaults($system->services);
+
+    $rows = [];
+    foreach ($svcNames as $svcName) {
+      /** @var \Loco\LocoService $svc */
+      $svc = $system->services[$svcName];
+      $env = $svc->createEnv();
+
+      foreach (['enabled'] as $prop) {
+        if ($showProp($prop) && $svc->{$prop}) {
+          $rows[] = [$svc->name, $prop, $svc->{$prop}];
+        }
+      }
+      foreach (['run', 'message', 'pid_file', 'log_file'] as $prop) {
+        if ($showProp($prop) && $svc->{$prop}) {
+          $rows[] = [$svc->name, $prop, $env->evaluate($svc->{$prop})];
+        }
+      }
+    }
+    $table = new Table($output);
+    $table
+      ->setHeaders(['Service', 'Key', 'Value'])
+      ->setRows($rows);
+    $table->render();
+
+    return 0;
+  }
+
+}

--- a/src/Command/LocoCommandTrait.php
+++ b/src/Command/LocoCommandTrait.php
@@ -202,4 +202,22 @@ trait LocoCommandTrait {
     return $a == $b;
   }
 
+  /**
+   * Some defaults are different when executed as 'loco start' daemons.
+   *
+   * Fill in those details.
+   *
+   * @param \Loco\LocoService[] $services
+   */
+  protected function applyDaemonDefaults(array $services) {
+    foreach ($services as $svc) {
+      /** @var \Loco\LocoService $svc */
+      if (!($svc instanceof LocoVolume)) {
+        if (empty($svc->log_file)) {
+          $svc->log_file = '${LOCO_SVC_VAR}/loco.log';
+        }
+      }
+    }
+  }
+
 }

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -57,12 +57,10 @@ class StartCommand extends \Symfony\Component\Console\Command\Command {
           $output->writeln("<error>Service \"{$svcName}\" is not compatible with \"loco start\". Service must define \"run\" and \"pidFile\".</error>");
           return 1;
         }
-
-        if (empty($svc->log_file)) {
-          $svc->log_file = '${LOCO_SVC_VAR}/loco.log';
-        }
       }
     }
+
+    $this->applyDaemonDefaults($services);
 
     $postStartupMessages = [];
 


### PR DESCRIPTION
Example: View the "message" defined for each service
```
$ loco info -m

+------------+---------+----------------------------------------------------------------------------------------------------------------------+
| Service    | Key     | Value                                                                                                                |
+------------+---------+----------------------------------------------------------------------------------------------------------------------+
| apache-vdr | message | Apache HTTPD is running at "http://127.0.0.1:6000" with content from "/home/totten/bknix/build".                     |
| memcached  | message | Memcached is running on "127.0.0.1:6006".                                                                            |
| mysetup    | message | Buildkit (/home/totten/bknix) is configured to use these services. It produces builds in "/home/totten/bknix/build". |
| mysql      | message | MySQL is running on "127.0.0.1:6001". The default credentials are user="root" and password="".                       |
| php-fpm    | message | PHP-FPM is running on "127.0.0.1:6002"                                                                               |
| redis      | message | Redis is running on "127.0.0.1:6005".                                                                                |
+------------+---------+----------------------------------------------------------------------------------------------------------------------+
```

Example: View all available info (*as evaluated in the current environment*)

```
$ loco info
+------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Service    | Key      | Value                                                                                                                                                             |
+------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| apache-vdr | enabled  | 1                                                                                                                                                                 |
| apache-vdr | run      | apachectl -d "/home/totten/_bknix/ramdisk/worker-0/apache-vdr" -DFOREGROUND                                                                                       |
| apache-vdr | message  | Apache HTTPD is running at "http://127.0.0.1:6000" with content from "/home/totten/bknix/build".                                                                  |
| apache-vdr | pid_file | /home/totten/_bknix/ramdisk/worker-0/apache-vdr/httpd.pid                                                                                                         |
| apache-vdr | log_file | /home/totten/_bknix/ramdisk/worker-0/apache-vdr/loco.log                                                                                                          |
| memcached  | run      | memcached --port=6006 --pidfile="/home/totten/_bknix/ramdisk/worker-0/memcached/memcached.pid"                                                                    |
| memcached  | message  | Memcached is running on "127.0.0.1:6006".                                                                                                                         |
| memcached  | pid_file | /home/totten/_bknix/ramdisk/worker-0/memcached/memcached.pid                                                                                                      |
| memcached  | log_file | /home/totten/_bknix/ramdisk/worker-0/memcached/loco.log                                                                                                           |
| mysetup    | enabled  | 1                                                                                                                                                                 |
| mysetup    | message  | Buildkit (/home/totten/bknix) is configured to use these services. It produces builds in "/home/totten/bknix/build".                                              |
| mysetup    | log_file | /home/totten/_bknix/ramdisk/worker-0/mysetup/loco.log                                                                                                             |
| mysql      | enabled  | 1                                                                                                                                                                 |
| mysql      | run      | mysqld --datadir="/home/totten/_bknix/ramdisk/worker-0/mysql/data"                                                                                                |
| mysql      | message  | MySQL is running on "127.0.0.1:6001". The default credentials are user="root" and password="".                                                                    |
| mysql      | pid_file | /home/totten/_bknix/ramdisk/worker-0/mysql/run/mysql.pid                                                                                                          |
| mysql      | log_file | /home/totten/_bknix/ramdisk/worker-0/mysql/loco.log                                                                                                               |
| php-fpm    | enabled  | 1                                                                                                                                                                 |
| php-fpm    | run      | php-fpm -y "/home/totten/_bknix/ramdisk/worker-0/php-fpm/php-fpm.conf" --nodaemonize                                                                              |
| php-fpm    | message  | PHP-FPM is running on "127.0.0.1:6002"                                                                                                                            |
| php-fpm    | pid_file | /home/totten/_bknix/ramdisk/worker-0/php-fpm/php-fpm.pid                                                                                                          |
| php-fpm    | log_file | /home/totten/_bknix/ramdisk/worker-0/php-fpm/loco.log                                                                                                             |
| redis      | enabled  | 1                                                                                                                                                                 |
| redis      | run      | redis-server --port "6005" --bind "127.0.0.1" --pidfile "/home/totten/_bknix/ramdisk/worker-0/redis/redis.pid" --dir "/home/totten/_bknix/ramdisk/worker-0/redis" |
| redis      | message  | Redis is running on "127.0.0.1:6005".                                                                                                                             |
| redis      | pid_file | /home/totten/_bknix/ramdisk/worker-0/redis/redis.pid                                                                                                              |
| redis      | log_file | /home/totten/_bknix/ramdisk/worker-0/redis/loco.log                                                                                                               |
+------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
