### PR TITLE
Fix regression in 'export' command

### DIFF
--- a/src/Command/ExportCommand.php
+++ b/src/Command/ExportCommand.php
@@ -62,6 +62,7 @@ class ExportCommand extends \Symfony\Component\Console\Command\Command {
           ));
       }
     }
+    return 0;
   }
 
 }

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -41,6 +41,7 @@ class RunCommand extends \Symfony\Component\Console\Command\Command {
     else {
       $this->executeInManagedMode($input, $output);
     }
+    return 0;
   }
 
   /**


### PR DESCRIPTION
After some prior Symfony update, most subcommands were updated. But apparently this slipped through. It currently emits:

```
Uncaught TypeError: Return value of "Loco\Command\ExportCommand::execute()" must be of the type int, "null" returned.
```